### PR TITLE
Fix Page Routing

### DIFF
--- a/src/app/about/about.tsx
+++ b/src/app/about/about.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React, { useContext } from 'react';
 import '@/styles/globals.scss';
 import { ThemeContext } from '@/context/themeContext';

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,5 +1,9 @@
-import Home from '@/app/home';
+import About from '@/app/about/about';
 
 export default function AboutPage() {
-    return <Home initialSection="about" />;
+  return (
+    <div className="relative flex flex-[2] m-4 lg:mx-auto lg:mt-0 lg:mb-8 overflow-y-auto">
+      <About />
+    </div>
+  );
   }

--- a/src/app/experience/experience.tsx
+++ b/src/app/experience/experience.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React, { useContext } from 'react';
 import '@/styles/globals.scss';
 import { ThemeContext } from '@/context/themeContext';

--- a/src/app/experience/page.tsx
+++ b/src/app/experience/page.tsx
@@ -1,5 +1,9 @@
-import Home from '@/app/home';
+import Experience from '@/app/experience/experience';
 
 export default function ExperiencePage() {
-    return <Home initialSection="experience" />;
+  return (
+    <div className="relative flex flex-[2] m-4 lg:mx-auto lg:mt-0 lg:mb-8 overflow-y-auto">
+      <Experience />
+    </div>
+  );
   }

--- a/src/app/home.tsx
+++ b/src/app/home.tsx
@@ -1,90 +1,15 @@
 'use client';
 
 import '@/styles/globals.scss';
-import React, { useState } from 'react';
-import ParticleField from '@/components/particleField';
-import Header from '@/components/header';
-import ThemeSwitcher from '@/components/themeSwitcher';
+import React from 'react';
 import BusinessCard from '@/components/businessCard';
-import About from '@/app/about/about';
-import Experience from '@/app/experience/experience';
-import Works from '@/app/works/works';
-import LogoLoader from '@/components/loader';
-import Footer from '@/components/footer';
 
-interface HomeProps {
-  initialSection?: string;
-}
 
-const Home: React.FC<HomeProps> = ({ initialSection = 'businessCard' }) => {
-  const [currentSection, setCurrentSection] = useState<string>(initialSection);
-  const [isLoading, setIsLoading] = useState(true);
-  const [showContent, setShowContent] = useState(false);
-
-  const handleAnimationComplete = () => {
-    setIsLoading(false);
-    setTimeout(() => setShowContent(true), 250);
-  };
-
-  const renderSection = () => {
-    switch (currentSection) {
-      case 'about':
-        return (
-          <div className="relative flex flex-[2] m-4 lg:mx-auto lg:mt-0 lg:mb-8 overflow-y-auto">
-            <About />
-          </div>
-        );
-      case 'experience':
-        return (
-          <div className="relative flex flex-[2] m-4 lg:mx-auto lg:mt-0 lg:mb-8 overflow-y-auto">
-            <Experience />
-          </div>
-        );
-      case 'works':
-        return (
-          <div className="relative flex flex-[2] m-4 lg:mx-auto lg:mt-0 lg:mb-8 overflow-y-auto">
-            <Works />
-          </div>
-        );
-      case 'businessCard':
-      default:
-        return (
-          <div className="relative flex m-auto lg:absolute lg:top-1/2 lg:left-1/2 lg:-translate-x-1/2 lg:-translate-y-1/2 pointer-events-none [&_*]:pointer-events-auto">
-            <BusinessCard />
-          </div>
-        );
-    }
-  };
+const Home: React.FC = () => {
 
   return (
-    <div className="relative h-[100dvh] bg-bg text-fgSoft p-4 lg:p-8 transition-colors duration-[250ms] overflow-clip">
-      <div className="relative flex flex-col h-full justify-between border border-fgHard min-h-[calc(100dvh-2rem)] md:min-h-[calc(100dvh-4rem)] transition-colors duration-[250ms]">
-        <ParticleField color="rgb(110, 110, 110)" />
-        {isLoading ? (
-          <LogoLoader onAnimationComplete={handleAnimationComplete} />
-        ) : (
-          showContent && (
-            <>
-              <header className="flex relative w-full md:w-[calc(100%-2rem)] lg:w-[calc(100%-4rem)] h-fit my-4 lg:mt-8 lg:mb-16 mx-auto justify-between pointer-events-none">
-                <div className="relative flex mx-auto md:max-lg:ml-0 lg:justify-center">
-                  <Header setCurrentSection={setCurrentSection} />
-                </div>
-                <div className="max-md:hidden relative flex justify-end lg:absolute lg:top-0 lg:right-0 lg:m-0 pointer-events-auto  ">
-                  <ThemeSwitcher />
-                </div>
-              </header>
-              {renderSection()}
-              <div className="md:hidden relative flex justify-end m-4 pointer-events-auto">
-                <ThemeSwitcher />
-              </div>
-            </>
-          )
-        )}
-      </div>
-      
-      <footer className="relative w-fit h-fit m-auto ml-0 flex">
-        <Footer />
-      </footer>
+    <div className="relative flex m-auto lg:absolute lg:top-1/2 lg:left-1/2 lg:-translate-x-1/2 lg:-translate-y-1/2 pointer-events-none [&_*]:pointer-events-auto">
+      <BusinessCard />
     </div>
   );
 };

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,10 @@ import type { Metadata, Viewport } from "next";
 import "@/styles/globals.scss";
 import "@/styles/variables.scss";
 import { ThemeProvider } from '@/context/themeContext';
+import ParticleField from "@/components/particleField";
+import Header from "@/components/header";
+import ThemeSwitcher from "@/components/themeSwitcher";
+import Footer from "@/components/footer";
 
 export const metadata: Metadata = {
   title: "kierancanter.dev",
@@ -80,7 +84,30 @@ export default function RootLayout({
       <body className="antialiased bg-bg text-fgSoft selection:text-bg selection:bg-fgSoft">
         <ThemeProvider>
           <a href="#main-content" className="sr-only focus:not-sr-only">Skip to main content</a>
-          {children}
+          <div className="relative h-[100dvh] bg-bg text-fgSoft p-4 lg:p-8 transition-colors duration-[250ms] overflow-clip">
+            <div className="relative flex flex-col h-full justify-between border border-fgHard min-h-[calc(100dvh-2rem)] md:min-h-[calc(100dvh-4rem)] transition-colors duration-[250ms]">
+              <ParticleField color="rgb(110, 110, 110)" />
+              <header className="flex relative w-full md:w-[calc(100%-2rem)] lg:w-[calc(100%-4rem)] h-fit my-4 lg:mt-8 lg:mb-16 mx-auto justify-between pointer-events-none">
+                <div className="relative flex mx-auto md:max-lg:ml-0 lg:justify-center">
+                  <Header />
+                </div>
+                <div className="max-md:hidden relative flex justify-end lg:absolute lg:top-0 lg:right-0 lg:m-0 pointer-events-auto  ">
+                  <ThemeSwitcher />
+                </div>
+              </header>
+              
+              {children}
+
+              <div className="md:hidden relative flex justify-end m-4 pointer-events-auto">
+                <ThemeSwitcher />
+              </div>
+            </div>
+            
+            <footer className="relative w-fit h-fit m-auto ml-0 flex">
+              <Footer />
+            </footer>
+          </div>
+
         </ThemeProvider>
       </body>
     </html>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,10 @@
 import Home from '@/app/home';
 
 export default function Page() {
-  return <Home initialSection="businessCard" />;
+  return (
+    <div className="relative flex m-auto lg:absolute lg:top-1/2 lg:left-1/2 lg:-translate-x-1/2 lg:-translate-y-1/2 pointer-events-none [&_*]:pointer-events-auto">
+      <Home />
+    </div>
+  );
 }
 

--- a/src/app/works/page.tsx
+++ b/src/app/works/page.tsx
@@ -1,5 +1,9 @@
-import Home from '@/app/home';
+import Works from '@/app/works/works';
 
 export default function WorksPage() {
-    return <Home initialSection="works" />;
+    return (
+      <div className="relative flex flex-[2] m-4 lg:mx-auto lg:mt-0 lg:mb-8 overflow-y-auto">
+        <Works />
+      </div>
+    );
   }

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -1,47 +1,35 @@
-'use-client';
+'use client';
 
-import { useState } from 'react';
+import { usePathname } from 'next/navigation';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faUserTie } from '@fortawesome/free-solid-svg-icons';
+import Link from 'next/link';
 
-interface HeaderProps {
-  setCurrentSection: (section: string) => void;
-}
-
-const Header: React.FC<HeaderProps> = ({ setCurrentSection }) => {
-  const [selectedSection, setSelectedSection] = useState('businessCard');
-
-  const handleSectionClick = (section: string) => {
-    setCurrentSection(section);
-    setSelectedSection(section);
-  };
+const Header: React.FC = () => {
+  const pathname = usePathname();
 
   return (
     <nav id="header-links" className="relative flex flex-row justify-between items-center w-fit h-fit gap-8 pointer-events-none [&_*]:pointer-events-auto ">
-      <button
-        onClick={() => handleSectionClick('businessCard')}
-        className={`header-link ${selectedSection === 'businessCard' ? 'text-fgContrast' : 'text-fgSoft'}`}
+      <Link href='/' passHref
+        className={`header-link ${pathname === '/' ? 'text-fgContrast' : 'text-fgSoft'}`}
       >
         <FontAwesomeIcon icon={faUserTie} />
-      </button>
-      <button
-        onClick={() => handleSectionClick('about')}
-        className={`header-link ${selectedSection === 'about' ? 'text-fgContrast' : 'text-fgSoft'}`}
+      </Link>
+      <Link href='/about' passHref
+        className={`header-link ${pathname === '/about' ? 'text-fgContrast' : 'text-fgSoft'}`}
       >
         ABOUT
-      </button>
-      <button
-        onClick={() => handleSectionClick('experience')}
-        className={`header-link ${selectedSection === 'experience' ? 'text-fgContrast' : 'text-fgSoft'}`}
+      </Link>
+      <Link href='/experience' passHref
+        className={`header-link ${pathname === '/experience' ? 'text-fgContrast' : 'text-fgSoft'}`}
       >
         EXPERIENCE
-      </button>
-      <button
-        onClick={() => handleSectionClick('works')}
-        className={`header-link ${selectedSection === 'works' ? 'text-fgContrast' : 'text-fgSoft'}`}
+      </Link>
+      <Link href='/works' passHref
+        className={`header-link ${pathname === '/works' ? 'text-fgContrast' : 'text-fgSoft'}`}
       >
         WORKS
-      </button>
+      </Link>
     </nav>
   );
 };


### PR DESCRIPTION
Reformatted files and linking refs to properly route pages to corresponding content i.e. the about section is accessible from /about and shows proper URL on click of header link, etc. Incorporated `usePathname` from `next/navigation` to properly assign link color to active header.

From issue #7 