### PR TITLE
Accessibility Update 1

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,6 +336,8 @@ Visuals of the test and related metrics can be seen below:
 
 As you can see, the overall performance was vastly improved. With a reduction in average update time of 27.8%, the particle field now runs much smoother and more efficiently. While the minimum update time seemed to decrease, this may be explained by uncontrollable hardware factors like memory access patterns and CPU scheduling. The maximum update time drastically improved by 56.7%, and the variance by 67.8%. This means that the particle field is now more consistent and predictable.
 
+**01/09/2025:** To increase accessibility and promote better minimalism, I've reduced the interactivity of the particle field to activating only while the primary mouse button is pressed. As such, the feature still exists as a unique interaction, but it's not as intrusive or distracting to those with motion sensitivities.
+
 ### Theme Switcher
 
 The theme switcher component was one that I battled with while choosing the best design. I considered several solutions to swap between four themes:

--- a/src/components/about.tsx
+++ b/src/components/about.tsx
@@ -49,7 +49,7 @@ const About: React.FC<{ isActive: boolean }> = ({ isActive }) => {
       key={updateKey}
       id="about-container"
       ref={aboutRef}
-      className="relative flex flex-col w-full lg:w-kic-width h-fit p-2 text-fgSoft bg-black/10 rounded-sm transition-colors duration-250 hover:bg-black/20 lg:pointer-events-auto"
+      className="relative flex flex-col w-full lg:w-kic-width h-fit p-2 text-fgSoft bg-itemCardBg rounded-sm transition-colors duration-250 hover:bg-itemCardBgHover lg:pointer-events-auto"
       aria-label="About Me"
     >
       <article>

--- a/src/components/businessCard.tsx
+++ b/src/components/businessCard.tsx
@@ -150,7 +150,7 @@ export default function BusinessCard({ isActive }: { isActive: boolean }) {
           data-umami-event="Logo Click"
           className="relative aspect-square w-5 md:w-6 h-fit active:opacity-85 fill-[#1e1e1e] hover:fill-gray-500 transition duration-250" 
           href="https://www.youtube.com/watch?v=YHgwxVCiMyI" 
-          title="Impressive. Very nice. Let's see Paul Allen's card." 
+          title="Impressive. Very nice. Let's see Paul Allen's card."
           target="_blank" 
           rel="noopener noreferrer" 
           aria-label="Logo: Link to an American Psycho video reference"
@@ -169,8 +169,8 @@ export default function BusinessCard({ isActive }: { isActive: boolean }) {
 
         {/* Social Links */}
         <div 
-          id="socials" 
-          className="relative text-sm lg:text-base flex w-full h-fit mx-auto justify-between"
+          id="socials"
+          className="relative text-base flex w-full h-fit mx-auto justify-between"
           aria-label="Social media links"
         >
           {socialLinks.map((link) => (

--- a/src/components/businessCard.tsx
+++ b/src/components/businessCard.tsx
@@ -179,6 +179,7 @@ export default function BusinessCard({ isActive }: { isActive: boolean }) {
               data-umami-event="Social Click"
               data-umami-event-platform={link.title.toLowerCase()}
               href={link.href}
+              title={link.title}
               className="hover:text-gray-500 active:opacity-85 transition-all duration-250"
               aria-label={`Visit ${link.title} profile`}
               target="_blank"

--- a/src/components/experience.tsx
+++ b/src/components/experience.tsx
@@ -67,7 +67,7 @@ const Experience: React.FC<{ isActive: boolean }> = ({ isActive }) => {
                 experienceRefs.current[index] = element;
               }
             }} 
-            className="relative flex flex-col justify-between gap-2 w-full p-2 bg-black/10 rounded-sm transition-colors duration-250 hover:bg-black/20 lg:pointer-events-auto"
+            className="relative flex flex-col justify-between gap-2 w-full p-2 bg-itemCardBg rounded-sm transition-colors duration-250 hover:bg-black/50 lg:pointer-events-auto"
           >
             {/* Header: Position and Timeline Dot */}
             <header className="w-full h-fit flex flex-row justify-between items-center">

--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -18,7 +18,7 @@ const Footer = () => {
       <p className="group text-center font-ibm-plex-serif text-fgSoft text-[10px] font-medium hover:text-fgContrast hover:selection:bg-fgContrast transition-colors duration-250">
         with passion by <span className="font-spectral-sc font-semibold group-hover:selection:bg-fgContrast" aria-label="Kieran Canter">
           Kieran CANTER
-        </span> — <span aria-label="Current year">{new Date().getFullYear()}</span>
+        </span>
       </p>
     </Link>
   );

--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -15,7 +15,7 @@ const Footer = () => {
       rel="noopener noreferrer"
       aria-label="View source code on GitHub, made with passion by Kieran Canter"
     >
-      <p className="group text-center font-ibm-plex-serif text-fgSoft text-[10px] font-medium hover:text-fgContrast hover:selection:bg-fgContrast transition-colors duration-250">
+      <p className="group text-center font-ibm-plex-serif text-fgHard text-[10px] font-medium hover:text-fgContrast hover:selection:bg-fgContrast transition-colors duration-250">
         with passion by <span className="font-spectral-sc font-semibold group-hover:selection:bg-fgContrast" aria-label="Kieran Canter">
           Kieran CANTER
         </span>

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -64,7 +64,7 @@ const Header: React.FC<HeaderProps> = ({ activeTab, onTabChange }) => {
       <button
         ref={buttonRefs.home}
         onClick={() => onTabChange('home')}
-        className={`header-link ${activeTab === 'home' ? 'text-fgContrast' : 'text-fgSoft'}`}
+        className={`header-link ${activeTab === 'home' ? 'text-fgContrast' : 'text-fgHard'}`}
         aria-label="Home"
         aria-current={activeTab === 'home' ? 'page' : undefined}
       >
@@ -75,7 +75,7 @@ const Header: React.FC<HeaderProps> = ({ activeTab, onTabChange }) => {
       <button
         ref={buttonRefs.about}
         onClick={() => onTabChange('about')}
-        className={`header-link ${activeTab === 'about' ? 'text-fgContrast' : 'text-fgSoft'}`}
+        className={`header-link ${activeTab === 'about' ? 'text-fgContrast' : 'text-fgHard'}`}
         aria-current={activeTab === 'about' ? 'page' : undefined}
       >
         ABOUT
@@ -85,7 +85,7 @@ const Header: React.FC<HeaderProps> = ({ activeTab, onTabChange }) => {
       <button
         ref={buttonRefs.experience}
         onClick={() => onTabChange('experience')}
-        className={`header-link ${activeTab === 'experience' ? 'text-fgContrast' : 'text-fgSoft'}`}
+        className={`header-link ${activeTab === 'experience' ? 'text-fgContrast' : 'text-fgHard'}`}
         aria-current={activeTab === 'experience' ? 'page' : undefined}
       >
         EXPERIENCE
@@ -95,7 +95,7 @@ const Header: React.FC<HeaderProps> = ({ activeTab, onTabChange }) => {
       <button
         ref={buttonRefs.works}
         onClick={() => onTabChange('works')}
-        className={`header-link ${activeTab === 'works' ? 'text-fgContrast' : 'text-fgSoft'}`}
+        className={`header-link ${activeTab === 'works' ? 'text-fgContrast' : 'text-fgHard'}`}
         aria-current={activeTab === 'works' ? 'page' : undefined}
       >
         WORKS

--- a/src/components/particleField.tsx
+++ b/src/components/particleField.tsx
@@ -72,6 +72,7 @@ const ParticleField: React.FC<ParticleFieldProps> = ({ color }) => {
     let grid: Particle[][][] = [];
     let lastUpdateTime = 0;
     const UPDATE_INTERVAL = 1000 / 60; // Target 60 updates per second
+    let isMousePressed = false;
 
     /**
      * Initialize the particle system
@@ -103,6 +104,16 @@ const ParticleField: React.FC<ParticleFieldProps> = ({ color }) => {
     const handleMouseLeave = () => {
       if (isMobile()) return;
       isMouseOverField = false;
+    };
+
+    const handleMouseDown = (e: MouseEvent) => {
+      if (isMobile() || e.button !== 0) return; // Only respond to left mouse button
+      isMousePressed = true;
+    };
+
+    const handleMouseUp = (e: MouseEvent) => {
+      if (isMobile() || e.button !== 0) return;
+      isMousePressed = false;
     };
 
     /**
@@ -194,8 +205,8 @@ const ParticleField: React.FC<ParticleFieldProps> = ({ color }) => {
     const updateParticlePositions = () => {
       updateGrid();
 
-      // Only process particles near mouse when mouse is over field
-      if (isMouseOverField && !isMobile()) {
+      // Only process particles when mouse is pressed and over field
+      if (isMouseOverField && isMousePressed && !isMobile()) {
         const gridX = Math.floor(mouseX / CELL_SIZE);
         const gridY = Math.floor(mouseY / CELL_SIZE);
 
@@ -265,6 +276,8 @@ const ParticleField: React.FC<ParticleFieldProps> = ({ color }) => {
     container.addEventListener('mousemove', updateMousePosition);
     container.addEventListener('mouseenter', handleMouseEnter);
     container.addEventListener('mouseleave', handleMouseLeave);
+    container.addEventListener('mousedown', handleMouseDown);
+    container.addEventListener('mouseup', handleMouseUp);
     window.addEventListener('resize', resizeCanvas);
 
     // Cleanup
@@ -273,6 +286,8 @@ const ParticleField: React.FC<ParticleFieldProps> = ({ color }) => {
       container.removeEventListener('mousemove', updateMousePosition);
       container.removeEventListener('mouseenter', handleMouseEnter);
       container.removeEventListener('mouseleave', handleMouseLeave);
+      container.removeEventListener('mousedown', handleMouseDown);
+      container.removeEventListener('mouseup', handleMouseUp);
       window.removeEventListener('resize', resizeCanvas);
     };
   }, [color]);

--- a/src/components/themeSwitcher.tsx
+++ b/src/components/themeSwitcher.tsx
@@ -43,10 +43,10 @@ const ThemeSwitcher: React.FC = () => {
    */
   const ThemeToggle = ({ label, isActive, onToggle }: { label: string; isActive: boolean; onToggle: () => void }) => (
     <div className="flex items-center gap-2">
-      <h4 className="max-lg:hidden font-ibm-plex-sans text-base font-medium text-fgSoft select-none">{label.toLowerCase()}</h4>
+      <h4 className="max-lg:hidden font-ibm-plex-sans text-base font-medium text-fgHard select-none">{label.toLowerCase()}</h4>
       <div className="relative w-24 lg:w-4 h-10 lg:h-4 cursor-pointer" onClick={onToggle}>
-        <div className={`absolute flex items-center justify-center inset-0 border ${ isActive ? 'border-fgHard' : 'border-fgSoft' } `}>
-          <h4 className={`lg:hidden font-ibm-plex-sans text-base font-medium z-10 ${ isActive ? 'text-bg' : 'text-fgSoft' } `}>{label.toUpperCase()}</h4>
+        <div className={`absolute flex items-center justify-center inset-0 border ${ isActive ? 'border-fgHard' : 'border-fgHard' } `}>
+          <h4 className={`lg:hidden font-ibm-plex-sans text-base font-medium z-10 ${ isActive ? 'text-bg' : 'text-fgHard' } `}>{label.toUpperCase()}</h4>
         </div>
         <div className={`absolute bg-fgHard inset-0 transition-opacity duration-250 ${ isActive ? 'opacity-60 lg:opacity-60 hover:opacity-80' : 'opacity-0 hover:opacity-20' } `} />
       </div>

--- a/src/components/works.tsx
+++ b/src/components/works.tsx
@@ -69,7 +69,7 @@ const Works: React.FC<{ isActive: boolean }> = ({ isActive }) => {
               worksRefs.current[index] = element;
             }
           }} 
-          className="relative flex flex-col justify-between gap-2 w-full p-2 bg-black/10 rounded-sm transition-colors duration-250 hover:bg-black/20 lg:pointer-events-auto"
+          className="relative flex flex-col justify-between gap-2 w-full p-2 bg-itemCardBg rounded-sm transition-colors duration-250 hover:bg-itemCardBgHover lg:pointer-events-auto"
           role="article"
           aria-labelledby={`project-title-${index}`}
         >
@@ -151,7 +151,6 @@ const Works: React.FC<{ isActive: boolean }> = ({ isActive }) => {
                   key={techIndex} 
                   className="text-[0.65rem] font-bold text-bg px-2 py-1 rounded-sm cursor-default transition duration-250 hover:opacity-85 selection:bg-bg selection:text-fgContrast"
                   style={{ backgroundColor: color }}
-                  role="listitem"
                 >
                   {tech}
                 </h6>

--- a/src/data/worksContent.ts
+++ b/src/data/worksContent.ts
@@ -10,11 +10,25 @@
  */
 export const worksContent = [
   {
+    project: 'RocketOdds',
+    githubURL: 'https://github.com/KieranCanter/',
+    description: "Plugin for the popular Rocket League mod, BakkesMod. Real-time moneyline win odds. Dynamically calculates win probabilities by analyzing in-game metrics like goals, shots, and possession. Uses historical datasets to predictively model accurate probabilities. Written in C++ using the Bakkesmod SDK.",
+    technologies: ['C++', 'Python', 'PyTorch', 'Pandas', 'NumPy', 'Matplotlib', 'scikit-learn'],
+    wip: true,
+  },
+  {
     project: 'kierancanter.dev',
     githubURL: 'https://github.com/kierancanter/kierancanter.dev',
     projectURL: 'https://kierancanter.dev',
     description: "The website you're viewing. Heavily focused on responsive design, accessibility, and pixel-perfect attention to detail. Roughly designed in Figma. Component prototypes tested in CodePen. Coded and developed in Cursor. Hosted on AWS and deployed with Vercel. Analytics tracked with Umami and stored through a PostgreSQL database on Supabase.",
     technologies: ['TypeScript', 'HTML5/CSS3', 'React', 'Next.js', 'Tailwind CSS', 'PostgreSQL'],
+    wip: false,
+  },
+  {
+    project: 'UFC Win Factors Model',
+    githubURL: 'https://github.com/kierancanter/ufcwinfactors',
+    description: "A statistical analysis performed on UFC fighter and event stats to determine the qualities and attributes most related to winning fights. The data science pipeline is displayed through a Jupyter Notebook as a tutorial-style modeling. Written in Python, leveraging many popular data science libraries.",
+    technologies: ['Python', 'Pandas', 'scikit-learn', 'XGBoost', 'Matplotlib', 'Seaborn'],
     wip: false,
   },
   {
@@ -26,24 +40,10 @@ export const worksContent = [
     wip: false,
   },
   {
-    project: 'UFC Win Factors Model',
-    githubURL: 'https://github.com/kierancanter/ufcwinfactors',
-    description: "A statistical analysis performed on UFC fighter and event stats to determine the qualities and attributes most related to winning fights. The data science pipeline is displayed through a Jupyter Notebook as a tutorial-style modeling. Written in Python, leveraging many popular data science libraries.",
-    technologies: ['Python', 'Pandas', 'Numpy', 'Matplotlib', 'scikit-learn', 'XGBoost', 'Seaborn'],
-    wip: false,
-  },
-  {
     project: 'Simple Blackjack',
     githubURL: 'https://github.com/KieranCanter/SimpleBlackjack',
     description: "Simple, collaborative blackjack mobile application written for Android using Android Studio. Utilizes a Model-View-Controller architectural pattern. Automated builds and dependency management using Gradle.",
     technologies: ['Kotlin'],
     wip: false,
-  },
-  {
-    project: 'RocketOdds',
-    githubURL: 'https://github.com/KieranCanter/',
-    description: "Plugin for the popular Rocket League mod, BakkesMod. Real-time moneyline win odds. Dynamically calculates win probabilities by analyzing in-game metrics like goals, shots, and possession. Uses historical datasets to predictively model accurate probabilities. Written in C++ using the Bakkesmod SDK.",
-    technologies: ['C++', 'Python', 'PyTorch', 'Pandas', 'NumPy', 'Matplotlib', 'scikit-learn'],
-    wip: true,
   },
 ];

--- a/src/styles/variables.scss
+++ b/src/styles/variables.scss
@@ -29,6 +29,11 @@
 
   // Layout Constants
   --kic-width: max(calc(100vw*0.428571429), 40rem);
+
+  // Item Card Background
+  --item-card-bg: rgba(0, 0, 0, 0.2);
+  --item-card-bg-hover: rgba(0, 0, 0, 0.4);
+
 }
 
 /**

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -37,16 +37,16 @@ module.exports = {
           fgSoft: "var(--luminous-fg-soft)",
           fgHard: "var(--luminous-fg-hard)",
           fgContrast: "var(--luminous-fg-contrast)",
-        }
+        },
+
+        itemCardBg: "var(--item-card-bg)",
+        itemCardBgHover: "var(--item-card-bg-hover)",
       },
       transitionDuration: {
         '250': '250ms',
       },
       width: {
-        'kic-width': "var(--kic-width)"
-      },
-      margin: {
-        'kic-margin': "var(--kic-margin)"
+        'kic-width': "var(--kic-width)",
       },
       fontFamily: {
         'spectral-sc': ['Spectral SC', 'Georgia', 'Times New Roman', 'serif'],


### PR DESCRIPTION
Refs: Issues #38 and #39

This PR contains many little revisions that increase the accessibility of the site:

* Removed date from footer to promote better minimalism (not accessibility-related)
* Moved RocketOdds item card to top of Works section to better portray recently worked on projects (not accessibility-related)
* Restricted particle field interactivity to only activate while mouse button is pressed to reduce distractions and intrusiveness to those with motion sensitivities
  * Logged change in README
* Replaced item card backgrounds with tailwind-to-CSS property variables (`bg-black/10` -> `bg-itemCardBg`)
  * Increased background opacity from 10% to 20% and hover background opacity from 20% to 40% to increase contrast ratio
* Changed colors of headings, footer, and theme switcher from FG Soft to FG Hard to display better contrast ratio
* Increased size of mobile social icons to improve mobile usability
* Add hover titles for social links to better telegraph external resources